### PR TITLE
Trap localStorage exceptions when checking for support

### DIFF
--- a/jquery.total-storage.js
+++ b/jquery.total-storage.js
@@ -46,13 +46,21 @@
 
 	/* Variables I'll need throghout */
 
-	var ls = (typeof window.localStorage === 'undefined') ? undefined : window.localStorage;
-	var supported;
-	if (typeof ls == 'undefined' || typeof window.JSON == 'undefined'){
-		supported = false;
-	} else {
-		supported = true;
+	var supported, ls;
+	if ('localStorage' in window){
+		try {
+			ls = (typeof window.localStorage === 'undefined') ? undefined : window.localStorage;
+			if (typeof ls == 'undefined' || typeof window.JSON == 'undefined'){
+				supported = false;
+			} else {
+				supported = true;
+			}
+		}
+		catch (err){
+			supported = false;
+		}
 	}
+
 	/* Make the methods public */
 
 	$.totalStorage = function(key, value, options){


### PR DESCRIPTION
One way to test this is to run Chrome and Firefox with cookies disabled, which also disables localStorage and sessionStorage by throwing an exception on any access attempt.

More information: http://www.w3.org/TR/webstorage/#the-localstorage-attribute
