### PR TITLE
Fix iOS Private Browsing / Chrome Icognito Error

### DIFF
--- a/jquery.total-storage.js
+++ b/jquery.total-storage.js
@@ -46,7 +46,7 @@
 
 	/* Variables I'll need throghout */
 
-	var supported, ls;
+	var supported, ls, mod = 'test';
 	if ('localStorage' in window){
 		try {
 			ls = (typeof window.localStorage === 'undefined') ? undefined : window.localStorage;
@@ -55,11 +55,15 @@
 			} else {
 				supported = true;
 			}
+			
+			window.localStorage.setItem(mod, '1');
+			window.localStorage.removeItem(mod);
 		}
 		catch (err){
 			supported = false;
 		}
 	}
+
 
 	/* Make the methods public */
 


### PR DESCRIPTION
Updated the support tests due to iOS and Chrome throwing errors when using set/get when in private browsing mode.

Currently iOS/Chrome will pass the support test but no data will be stored.

This change forces cookie usage for those modes stopping the failure.
